### PR TITLE
Tooltip Changed, and renaming

### DIFF
--- a/grails-app/domain/edu/mtu/cs/queue/QueueQuestion.groovy
+++ b/grails-app/domain/edu/mtu/cs/queue/QueueQuestion.groovy
@@ -3,7 +3,7 @@ package edu.mtu.cs.queue
 import edu.mtu.MtuConstants
 import edu.mtu.cs.lti.Person
 
-class QueueQuestion implements MtuConstants{
+class QueueQuestion implements MtuConstants {
 
     Person person
 
@@ -29,7 +29,7 @@ class QueueQuestion implements MtuConstants{
     Date dateCreated
     Date lastUpdated
 
-    static hasMany = [files: QueueFile, answers: QueueAnswer ]
+    static hasMany = [files: QueueFile, answers: QueueAnswer]
 
     static mapping = {
         message type: 'text'
@@ -45,14 +45,14 @@ class QueueQuestion implements MtuConstants{
         deletedBy(nullable: true)
     }
 
-    public String location( ) {
+    public String location() {
         String result = "Off Campus"
-        if ( hostname?.endsWith("mtu.edu") ) {
+        if (hostname?.endsWith("mtu.edu")) {
             result = "On Campus"
-            if ( hostname.startsWith("cslc") ) {
-                result = "CSLC Rekhi 118"
-            } else if ( hostname.startsWith("c") ) {
-                result = BUILDINGS[hostname.substring(1,4)] + " " + hostname.substring(5,9) + " " + hostname.substring(11,13)
+            if (hostname.startsWith("cclc")) {
+                result = "CCLC Rekhi 118"
+            } else if (hostname.startsWith("c")) {
+                result = BUILDINGS[hostname.substring(1, 4)] + " " + hostname.substring(5, 9) + " " + hostname.substring(11, 13)
             } else if (hostname.startsWith("rover")) {
                 result = "Rovernet"
             }

--- a/grails-app/services/edu/mtu/cs/lti/LtiSessionService.groovy
+++ b/grails-app/services/edu/mtu/cs/lti/LtiSessionService.groovy
@@ -14,5 +14,4 @@ interface LtiSessionService {
     void delete(Serializable id)
 
     LtiSession save(LtiSession ltiSession)
-
 }

--- a/grails-app/views/queue/coach.gsp
+++ b/grails-app/views/queue/coach.gsp
@@ -24,7 +24,7 @@
     <br>
     <ul class="nav nav-tabs nav-justified">
         <li class="active"><a data-toggle="tab" href="#OpenQuestions">Open Questions</a></li>
-        <li><a data-toggle="tab" href="#AnsweredQuestions">Answered Questions</a></li>
+        <li><a data-toggle="tab" href="#CourseQuestions">Course Questions</a></li>
     </ul>
 
     <div class="tab-content">
@@ -95,10 +95,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#openModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
                                         <!-- Modal -->
@@ -161,10 +161,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -177,7 +177,7 @@
             </div>
         </div>
 
-        <div id="AnsweredQuestions" class="tab-pane fade">
+        <div id="CourseQuestions" class="tab-pane fade">
             <div class='panel panel-info'>
                 <g:if test="${answeredQuestions == null || answeredQuestions.isEmpty()}">
                     <div class='container-fluid panel-heading' style="padding: 0 !important;">
@@ -244,10 +244,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#myModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
 
@@ -311,10 +311,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -349,11 +349,10 @@
                                                     <g:hiddenField name="answer" value="${answer.id}"/>
                                                     <button type="submit" name="submit"
                                                             class="btn btn-info btn-lg"
-                                                            aria-label="Delete this Answer">
-                                                        <div data-toggle="tooltip" title="Delete this Answer"><span
-                                                                class="glyphicon glyphicon-trash"
-                                                                aria-hidden="true"></span>
-                                                        </div>
+                                                            aria-label="Delete this Answer"
+                                                            data-toggle="tooltip"
+                                                            title="Delete this Answer">
+                                                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                     </button>
                                                 </g:form>
                                             </div>

--- a/grails-app/views/queue/gta.gsp
+++ b/grails-app/views/queue/gta.gsp
@@ -89,10 +89,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#openModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
                                         <!-- Modal -->
@@ -155,10 +155,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -232,10 +232,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#myModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
 
@@ -299,10 +299,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -337,11 +337,10 @@
                                                     <g:hiddenField name="answer" value="${answer.id}"/>
                                                     <button type="submit" name="submit"
                                                             class="btn btn-info btn-lg"
-                                                            aria-label="Delete this Answer">
-                                                        <div data-toggle="tooltip" title="Delete this Answer"><span
-                                                                class="glyphicon glyphicon-trash"
-                                                                aria-hidden="true"></span>
-                                                        </div>
+                                                            aria-label="Delete this Answer"
+                                                            data-toggle="tooltip"
+                                                            title="Delete this Answer">
+                                                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                     </button>
                                                 </g:form>
                                             </div>

--- a/grails-app/views/queue/instructor.gsp
+++ b/grails-app/views/queue/instructor.gsp
@@ -24,7 +24,7 @@
     <br>
     <ul class="nav nav-tabs nav-justified">
         <li class="active"><a data-toggle="tab" href="#OpenQuestions">Open Questions</a></li>
-        <li><a data-toggle="tab" href="#AnsweredQuestions">Answered Questions</a></li>
+        <li><a data-toggle="tab" href="#CourseQuestions">Course Questions</a></li>
     </ul>
 
     <div class="tab-content">
@@ -89,10 +89,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#openModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
                                         <!-- Modal -->
@@ -155,10 +155,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -171,7 +171,7 @@
             </div>
         </div>
 
-        <div id="AnsweredQuestions" class="tab-pane fade">
+        <div id="CourseQuestions" class="tab-pane fade">
             <div class='panel panel-info'>
                 <g:if test="${answeredQuestions == null || answeredQuestions.isEmpty()}">
                     <div class='container-fluid panel-heading' style="padding: 0 !important;">
@@ -232,10 +232,10 @@
                                         <div style="padding: 5px !important;">
                                             <button type="button" class="btn btn-info btn-lg" data-toggle="modal"
                                                     data-target="${'#myModal' + question.id}"
-                                                    aria-label="Answer the Question"><div
-                                                    data-toggle="tooltip" title="Answer the Question"><span
-                                                        class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-                                            </div>
+                                                    aria-label="Answer the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Answer the Question">
+                                                    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                             </button>
                                         </div>
 
@@ -299,10 +299,10 @@
                                             <g:hiddenField name="question" value="${question.id}"/>
                                             <button type="submit" name="submit"
                                                     class="btn btn-info btn-lg"
-                                                    aria-label="Delete the Question">
-                                                <div data-toggle="tooltip" title="Delete the Question"><span
-                                                        class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                                                </div>
+                                                    aria-label="Delete the Question"
+                                                    data-toggle="tooltip"
+                                                    title="Delete the Question">
+                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                             </button>
                                         </g:form>
                                     </div>
@@ -337,11 +337,10 @@
                                                     <g:hiddenField name="answer" value="${answer.id}"/>
                                                     <button type="submit" name="submit"
                                                             class="btn btn-info btn-lg"
-                                                            aria-label="Delete this Answer">
-                                                        <div data-toggle="tooltip" title="Delete this Answer"><span
-                                                                class="glyphicon glyphicon-trash"
-                                                                aria-hidden="true"></span>
-                                                        </div>
+                                                            aria-label="Delete this Answer"
+                                                            data-toggle="tooltip"
+                                                            title="Delete this Answer">
+                                                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                     </button>
                                                 </g:form>
                                             </div>

--- a/grails-app/views/queue/student.gsp
+++ b/grails-app/views/queue/student.gsp
@@ -63,6 +63,12 @@
                     <g:checkBox name="attention" value="${false}"/> <label for='attention'>Raise your hand.</label>
                 </div>
 
+                <div class='form-group'>
+                    <label>File Upload</label>
+                    <input type='file' name='myfile' multiple><br><br>
+                    <input type='submit'>
+                </div>
+
                 <div class='col-xs-12 btn-danger' style='display:none' id='questionError'></div>
                 <g:submitButton name="submit" value="Ask Question!" class='btn btn-success form-control'/>
             </g:form>
@@ -140,11 +146,10 @@
                                                     <button type="button" class="btn btn-info btn-lg"
                                                             data-toggle="modal"
                                                             data-target="${'#openModal' + question.id}"
-                                                            aria-label="Answer the Question"><div
-                                                            data-toggle="tooltip" title="Answer the Question"><span
-                                                                class="glyphicon glyphicon-comment"
-                                                                aria-hidden="true"></span>
-                                                    </div>
+                                                            aria-label="Answer the Question"
+                                                            data-toggle="tooltip"
+                                                            title="Answer the Question">
+                                                            <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                                     </button>
                                                 </div>
                                                 <!-- Modal -->
@@ -210,11 +215,10 @@
                                                     <g:hiddenField name="question" value="${question.id}"/>
                                                     <button type="submit" name="submit"
                                                             class="btn btn-info btn-lg"
-                                                            aria-label="Delete the Question">
-                                                        <div data-toggle="tooltip" title="Delete the Question"><span
-                                                                class="glyphicon glyphicon-trash"
-                                                                aria-hidden="true"></span>
-                                                        </div>
+                                                            aria-label="Delete the Question"
+                                                            data-toggle="tooltip"
+                                                            title="Delete the Question">
+                                                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                     </button>
                                                 </g:form>
                                             </div>
@@ -278,11 +282,10 @@
                                                     <button type="button" class="btn btn-info btn-lg"
                                                             data-toggle="modal"
                                                             data-target="${'#myModal' + question.id}"
-                                                            aria-label="Answer the Question"><div
-                                                            data-toggle="tooltip" title="Answer the Question"><span
-                                                                class="glyphicon glyphicon-comment"
-                                                                aria-hidden="true"></span>
-                                                    </div>
+                                                            aria-label="Answer the Question"
+                                                            data-toggle="tooltip"
+                                                            title="Answer the Question">
+                                                            <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
                                                     </button>
                                                 </div>
 
@@ -349,11 +352,10 @@
                                                     <g:hiddenField name="question" value="${question.id}"/>
                                                     <button type="submit" name="submit"
                                                             class="btn btn-info btn-lg"
-                                                            aria-label="Delete the Question">
-                                                        <div data-toggle="tooltip" title="Delete the Question"><span
-                                                                class="glyphicon glyphicon-trash"
-                                                                aria-hidden="true"></span>
-                                                        </div>
+                                                            aria-label="Delete the Question"
+                                                            data-toggle="tooltip"
+                                                            title="Delete the Question">
+                                                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                     </button>
                                                 </g:form>
                                             </div>
@@ -389,12 +391,10 @@
                                                             <g:hiddenField name="answer" value="${answer.id}"/>
                                                             <button type="submit" name="submit"
                                                                     class="btn btn-info btn-lg"
-                                                                    aria-label="Delete this Answer">
-                                                                <div data-toggle="tooltip"
-                                                                     title="Delete this Answer"><span
-                                                                        class="glyphicon glyphicon-trash"
-                                                                        aria-hidden="true"></span>
-                                                                </div>
+                                                                    aria-label="Delete this Answer"
+                                                                    data-toggle="tooltip"
+                                                                    title="Delete this Answer">
+                                                                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                                                             </button>
                                                         </g:form>
                                                     </div>


### PR DESCRIPTION
-Tooltips for buttons that delete questions or answers, or create questions or answers are now on the button instead of the glyph

-Rename every instance from "CSLC" to "CCLC"